### PR TITLE
adding env_args feature to escalations

### DIFF
--- a/tests/unit/test_escalations.py
+++ b/tests/unit/test_escalations.py
@@ -1,0 +1,37 @@
+import unittest
+import unittest.mock as mock
+import os
+
+from mozalert import event
+
+from tests import events
+
+class TestEscalations(unittest.TestCase):
+    def test_escalation_parser(self):
+        event_blob = events.add_event
+        event_blob["object"]["spec"]["escalations"] = []
+        esc = { "type": "email", "args": { "email": "afrank@mozilla.com" } }
+
+        event_blob["object"]["spec"]["escalations"] += [esc]
+
+        # test to be sure "normal" escalation parsing works
+        evt = event.Event(**event_blob)
+
+        test_key = "MY_EMAIL"
+        test_email = "afrank+env@mozilla.com"
+
+        os.environ[test_key] = test_email
+
+        env_esc = { "type": "email", "env_args": { "email": test_key } }
+
+        event_blob["object"]["spec"]["escalations"] += [env_esc]
+
+        # this time we should have two escalations and one of them should be
+        # for afrank+env@mozilla.com
+        evt = event.Event(**event_blob)
+
+        assert len(evt.config.escalations) == 2, "Wrong number of escalations!"
+
+        assert evt.config.escalations[1]["args"]["email"] == test_email, "env_args were not parsed correctly!"
+
+        


### PR DESCRIPTION
In a Check manifest you can defined >=0 escalations, for example:
```
apiVersion: "crd.k8s.afrank.local/v1"
kind: Check
metadata:
  name: my-check
spec:
  check_interval: 1m
  max_attempts: 3
  escalations:
  - type: email
    args:
      email: afrank@mozilla.com
```
which is all well and good if your escalation argument is not secret, then you can store your check manifest in plaintext in git. The problem occurs when you have a secret argument you want to pass to an escalation. For example, to escalate to slack you must supply a webhook url, which is secret. To satisfy this use-case, this PR adds the "env_args" option, which works in addition to "args", for example:
```
  escalations:
  - type: slack
    env_args:
      webhook_url: "SLACK_DEFAULT_WEBHOOK_URL"
      channel: "SLACK_DEFAULT_CHANNEL"
```
This allows the user to supply secret information to the escalation using an env var, which can be supplied with a secret resource.

https://jira.mozilla.com/browse/SE-1163

@bowlofstew a review please.