### PR TITLE
adjusting logic for event modifications

### DIFF
--- a/mozalert/base.py
+++ b/mozalert/base.py
@@ -52,7 +52,15 @@ class BaseCheck:
 
         if self._pre_status:
             self._status.parse_pre_status(**self._pre_status)
-            self._next_interval = self.status.next_interval
+            if self._next_interval < self.status.next_interval:
+                # the next_interval from our pre-status is longer than
+                # the interval from our config, this could be because
+                # the user modified the interval, so lets use the lesser
+                # of the two.
+                self.status.next_check = now() + datetime.timedelta(seconds=self._next_interval)
+            else:
+                self._next_interval = self.status.next_interval
+
             self._pre_status = {}
 
         self.start_thread()

--- a/mozalert/controller.py
+++ b/mozalert/controller.py
@@ -115,9 +115,6 @@ class Controller(threading.Thread):
                 evt = event.Event(**crd_event)
 
                 # restart the controller if ERROR operation is detected.
-                # dying is harsh but in theory states should be preserved in the k8s object.
-                # I've only seen the ERROR state when applying changes to the CRD definition
-                # and in those cases restarting the controller pod is appropriate. TODO validate
                 if evt.ERROR:
                     logging.error("Received ERROR operation, Dying.")
                     self.terminate()
@@ -160,6 +157,7 @@ class Controller(threading.Thread):
                         kube=self.kube,
                         config=evt.config,
                         metrics_queue=self.metrics_queue,
+                        pre_status=evt.status,
                     )
 
         logging.info("Controller shut down")


### PR DESCRIPTION
Currently if you modify an existing check, the modification event deletes the check thread then creates a new one using the values from the config. The check is placed in "PENDING" status until the next check_interval is reached. This PR changes this around to work thusly:
- User modifies an existing check
- Running check is terminated, thread is deleted
- New check is created, status is used from the old check, so status/state are preserved
- If the intervals in the new config dictate the next_check should be sooner than what was read from the old status, use the lesser value. **

** The reason we do this is in case the user changed an interval. Lets say a check has an interval of an hour, and was installed 5 minutes ago. So the next_check is in 55 minutes. But then the user modifies the check to set the check_interval to 1 minute. We don't want to wait 55 minutes for the interval to be adjusted, we want the check to run in 1 minute. 

One thing I wasn't sure about is the inverse. Lets say a check has a check_interval of 1 minute, and is going to fire in 30 seconds, but the user modifies the check to have a check_interval of 1 hour. This PR will handle this such that the lesser interval will be used, so the check will fire in 30 seconds, then the next check will use the new schedule of 1 hour.  Perhaps we'd instead want to always use the adjusted interval? 

This PR also removes a validation TODO.

I didn't add tests to this PR because we've already got a test for event modifications.

https://jira.mozilla.com/browse/SE-1187