### PR TITLE
Afrank circuit breaker

### DIFF
--- a/mozalert/checkmonitor.py
+++ b/mozalert/checkmonitor.py
@@ -23,7 +23,9 @@ class CheckMonitor(threading.Thread):
         # max failures before considering the check run a failure
         self.failed_threshold = kwargs.get("failed_threshold", 0)
 
-        self.sequential_failed_run_threshold = kwargs.get("sequential_failed_run_threshold", 2)
+        self.sequential_failed_run_threshold = kwargs.get(
+            "sequential_failed_run_threshold", 2
+        )
 
         self.sequential_failed_runs = 0
 
@@ -94,7 +96,9 @@ class CheckMonitor(threading.Thread):
 
         if failed > self.failed_threshold:
             self.sequential_failed_runs += 1
-            logging.warning(f"Sequential Failed Sanity Checks: {self.sequential_failed_runs}")
+            logging.warning(
+                f"Sequential Failed Sanity Checks: {self.sequential_failed_runs}"
+            )
         else:
             self.sequential_failed_runs = 0
 
@@ -103,6 +107,8 @@ class CheckMonitor(threading.Thread):
         )
 
         if self.sequential_failed_runs > self.sequential_failed_run_threshold:
-            logging.error(f"Circuit breaker triggered: Sanity Check Sequential Failures {self.sequential_failed_runs} > {self.sequential_failed_run_threshold}")
+            logging.error(
+                f"Circuit breaker triggered: Sanity Check Sequential Failures {self.sequential_failed_runs} > {self.sequential_failed_run_threshold}"
+            )
 
         logging.info("Check Monitor finished")

--- a/mozalert/checkmonitor.py
+++ b/mozalert/checkmonitor.py
@@ -20,6 +20,13 @@ class CheckMonitor(threading.Thread):
 
         self.shutdown = kwargs.get("shutdown", lambda: False)
 
+        # max failures before considering the check run a failure
+        self.failed_threshold = kwargs.get("failed_threshold", 0)
+
+        self.sequential_failed_run_threshold = kwargs.get("sequential_failed_run_threshold", 2)
+
+        self.sequential_failed_runs = 0
+
         self.setName("check-monitor")
 
     def terminate(self):
@@ -85,8 +92,17 @@ class CheckMonitor(threading.Thread):
             else:
                 success += 1
 
+        if failed > self.failed_threshold:
+            self.sequential_failed_runs += 1
+            logging.warning(f"Sequential Failed Sanity Checks: {self.sequential_failed_runs}")
+        else:
+            self.sequential_failed_runs = 0
+
         logging.debug(
             f"sanity check finished with {success} success and {failed} failures"
         )
+
+        if self.sequential_failed_runs > self.sequential_failed_run_threshold:
+            logging.error(f"Circuit breaker triggered: Sanity Check Sequential Failures {self.sequential_failed_runs} > {self.sequential_failed_run_threshold}")
 
         logging.info("Check Monitor finished")


### PR DESCRIPTION
This PR adds a max failure threshold to the check monitor, and outputs an additional log entry if the threshold has been surpassed. I resisted adding self-termination into this for the sake of safety, but may add it in the future. Currently, the idea is the message will inform a side car which can handle out of band circuit breaking if needed. 

@bowlofstew a review please, and please let me know if you disagree with how I've handled this.

Given the nature of this it would be difficult to simulate this condition in a unit test (this is specifically for capturing the unknown), however I've made myself TechDebt story to think about it more (SE-1189).

https://jira.mozilla.com/browse/SE-1188