### PR TITLE
controller refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ node_modules
 
 site-checker-secrets.yaml
 *secrets.yaml
+
+# related to mozlenium testing
+check.js

--- a/mozalert/checks/__init__.py
+++ b/mozalert/checks/__init__.py
@@ -1,0 +1,1 @@
+from mozalert.checks import config, monitor, check, base, handler

--- a/mozalert/checks/base.py
+++ b/mozalert/checks/base.py
@@ -7,8 +7,9 @@ import importlib
 from types import SimpleNamespace
 import datetime
 
-from mozalert import status, metrics, checkconfig
+from mozalert import status, metrics, checks
 from mozalert.utils.dt import now
+
 
 class BaseCheck:
     """
@@ -40,7 +41,7 @@ class BaseCheck:
         if _config:
             self.config = _config
         else:
-            self.config = checkconfig.CheckConfig(**kwargs)
+            self.config = checks.config.CheckConfig(**kwargs)
 
         self.shutdown = False
         self._runtime = datetime.timedelta(seconds=0)
@@ -57,7 +58,9 @@ class BaseCheck:
                 # the interval from our config, this could be because
                 # the user modified the interval, so lets use the lesser
                 # of the two.
-                self.status.next_check = now() + datetime.timedelta(seconds=self._next_interval)
+                self.status.next_check = now() + datetime.timedelta(
+                    seconds=self._next_interval
+                )
             else:
                 self._next_interval = self.status.next_interval
 
@@ -156,7 +159,7 @@ class BaseCheck:
             self._next_interval = self.config.retry_interval
 
         # TODO we need to check if we've got metrics mixed in
-        if hasattr(self,"metrics_queue"):
+        if hasattr(self, "metrics_queue"):
             self.metrics_queue.put_many(
                 self.config.name,
                 self.config.namespace,
@@ -216,4 +219,3 @@ class BaseCheck:
         self._thread.start()
 
         self.status.next_check = now() + datetime.timedelta(seconds=self.next_interval)
-

--- a/mozalert/checks/check.py
+++ b/mozalert/checks/check.py
@@ -4,7 +4,8 @@ from time import sleep
 
 from types import SimpleNamespace
 
-from mozalert import base, status, metrics
+from mozalert import status, metrics
+from mozalert.checks import base
 from mozalert.utils.dt import now
 
 from mozalert.kubeclient import ApiException
@@ -199,4 +200,3 @@ class Check(base.BaseCheck, metrics.mixin.MetricsMixin):
             # failure is probably ok here, if the job doesn't exist
             logging.debug(sys.exc_info()[0])
             logging.debug(e)
-

--- a/mozalert/checks/config.py
+++ b/mozalert/checks/config.py
@@ -1,5 +1,6 @@
 import os
 
+
 class CheckConfig:
     """
     the CheckConfig is used by Check objects as well as Event objects.
@@ -97,8 +98,8 @@ class CheckConfig:
             if "env_args" in e:
                 if "args" not in e:
                     e["args"] = {}
-                for k,v in e["env_args"].items():
-                    e["args"][k] = os.environ.get(v,"")
+                for k, v in e["env_args"].items():
+                    e["args"][k] = os.environ.get(v, "")
                 del e["env_args"]
             _escalations += [e]
         return _escalations

--- a/mozalert/checks/handler.py
+++ b/mozalert/checks/handler.py
@@ -1,0 +1,111 @@
+import logging
+import threading
+from mozalert import checks
+
+
+class CheckHandler(threading.Thread):
+    """
+    the CheckHandler thread takes check events from the controller and process them as
+    they come in. Each event has an associated operation:
+        
+    ADDED: a new check has been created. the main thread creates a new check object which
+           creates a threading.Timer set to the check_interval.
+        
+    DELETED: a check has been removed. Cancel/resolve any running threads and delete the
+             check object.
+
+    MODIFIED: this can be triggered by the user patching their check, or by a check thread
+              updating the object status. NOTE: updating the status subresource SHOULD NOT
+              trigger a modify, this is probably a bug in k8s. when a check is updated the
+              changes are applied to the check object.
+
+    ERROR: this can occur sometimes when the CRD is changed; it causes the process to die
+           and restart.
+
+    """
+
+    def __init__(self, q, kube, metrics_queue, shutdown=lambda: False):
+        super().__init__()
+        self.q = q
+        self.shutdown = shutdown
+        self.kube = kube
+        self.metrics_queue = metrics_queue
+
+        self._checks = {}
+
+    @property
+    def checks(self):
+        return self._checks
+
+    @checks.setter
+    def checks(self, checks):
+        self._checks = checks
+
+    def terminate(self):
+        logging.info("Shutting down checks")
+        for c in self.checks.keys():
+            self._checks[c].terminate()
+        for c in self.checks.keys():
+            self._checks[c].thread.join()
+        logging.info("Finished shutting down checks")
+
+    def kill_check(self, check_name):
+        if check_name not in self.checks:
+            logging.warning(f"{check_name} not found in checks`")
+            return
+
+        self._checks[check_name].terminate()
+        del self._checks[check_name]
+
+    def run(self):
+        while not self.shutdown():
+            evt = self.q.get()
+            if not evt:
+                continue
+
+            if evt.ERROR:
+                logging.error("Received ERROR operation, Dying.")
+                self.terminate()
+                return
+
+            if evt.BADEVENT:
+                logging.warning(f"Received unexpected {evt.type}. Moving on.")
+                continue
+
+            logging.debug(f"{evt.type} operation detected for thread {evt}")
+
+            check_name = str(evt)
+            resource_version = evt.resource_version
+
+            if evt.ADDED:
+                # create a new check and read any
+                # found status back into the check
+                self._checks[check_name] = checks.check.Check(
+                    kube=self.kube,
+                    config=evt.config,
+                    metrics_queue=self.metrics_queue,
+                    pre_status=evt.status,
+                )
+
+            if evt.DELETED:
+                self.kill_check(check_name)
+
+            if evt.MODIFIED:
+                # a MODIFIED event could either be a config change or a status
+                # change, so we need to detect which it is
+                if dict(self.checks[check_name].config) == dict(evt.config):
+                    logging.debug("Detected a status change")
+                    continue
+
+                logging.info(f"Detected a config change to {evt}")
+
+                self.kill_check(check_name)
+
+                self._checks[check_name] = checks.check.Check(
+                    kube=self.kube,
+                    config=evt.config,
+                    metrics_queue=self.metrics_queue,
+                    pre_status=evt.status,
+                )
+        self.terminate()
+        logging.info("Check Handler Shutdown")

--- a/mozalert/events/__init__.py
+++ b/mozalert/events/__init__.py
@@ -1,0 +1,1 @@
+from mozalert.events import queue, event, handler

--- a/mozalert/events/event.py
+++ b/mozalert/events/event.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import logging
 import sys
 
-from mozalert.checkconfig import CheckConfig
+from mozalert.checks.config import CheckConfig
 
 
 class EventType(Enum):
@@ -128,6 +128,8 @@ class Event:
         """
         parse_time takes either a number (in minutes) or a formatted time string [XXh][XXm][XXs]
         """
+        if not time_str:
+            return timedelta(minutes=0)
         try:
             minutes = float(time_str)
             return timedelta(minutes=minutes)

--- a/mozalert/events/handler.py
+++ b/mozalert/events/handler.py
@@ -1,0 +1,45 @@
+import threading
+import logging
+import sys
+
+from mozalert import kubeclient
+
+
+class EventHandler(threading.Thread):
+    def __init__(self, **kwargs):
+        super().__init__()
+        self.kube = kwargs.get("kube", kubeclient.KubeClient())
+        self.shutdown = kwargs.get("shutdown", lambda: False)
+
+        self.domain = kwargs.get("domain", "crd.k8s.afrank.local")
+        self.version = kwargs.get("version", "v1")
+        self.plural = kwargs.get("plural", "checks")
+
+        self._stream_watch_timeout = kwargs.get("stream_watch_timeout", 5)
+        self.event_queue = kwargs.get("q")
+
+    def run(self):
+        resource_version = ""
+        logging.info("Waiting for events...")
+        while not self.shutdown():
+            stream = self.kube.Watch().stream(
+                self.kube.CustomObjectsApi.list_cluster_custom_object,
+                self.domain,
+                self.version,
+                self.plural,
+                resource_version=resource_version,
+                timeout_seconds=self._stream_watch_timeout,
+            )
+            for crd_event in stream:
+                # add events to the event queue
+                try:
+                    resource_version = (
+                        crd_event.get("object", {})
+                        .get("metadata", {})
+                        .get("resourceVersion", "")
+                    )
+                    self.event_queue.put(**crd_event)
+                except Exception as e:
+                    logging.error(e)
+                    logging.error(sys.exc_info()[0])
+        logging.info("Event Handler Shutdown")

--- a/mozalert/events/queue.py
+++ b/mozalert/events/queue.py
@@ -1,0 +1,35 @@
+import logging
+import queue
+from types import SimpleNamespace
+from mozalert.events.event import Event
+import sys
+
+
+class EventQueue:
+    def __init__(self):
+        self.q = queue.Queue()
+
+    def put(self, **kwargs):
+        try:
+            evt = Event(**kwargs)
+            self.q.put(evt)
+        except Exception as e:
+            logging.error(e)
+            logging.error(sys.exc_info()[0])
+
+    def get(self, timeout=3):
+        try:
+            evt = self.q.get(timeout=timeout)
+        except queue.Empty:
+            return
+
+        self.q.task_done()
+        return evt
+
+    @property
+    def q(self):
+        return self._q
+
+    @q.setter
+    def q(self, q):
+        self._q = q

--- a/mozalert/metrics/__init__.py
+++ b/mozalert/metrics/__init__.py
@@ -1,2 +1,1 @@
-
 from mozalert.metrics import thread, queue, mixin, config

--- a/mozalert/metrics/config.py
+++ b/mozalert/metrics/config.py
@@ -1,4 +1,3 @@
-
 MetricsConfig = {
     "mozalert_check_get_time": {"type": "Gauge", "labels": ["status", "escalated"],},
     "mozalert_check_node_time": {"type": "Gauge", "labels": ["status", "escalated"],},
@@ -8,4 +7,3 @@ MetricsConfig = {
     "mozalert_check_escalations": {"type": "Gauge", "labels": [],},
     "mozalert_check_failures": {"type": "Gauge", "labels": [],},
 }
-

--- a/mozalert/metrics/mixin.py
+++ b/mozalert/metrics/mixin.py
@@ -1,6 +1,6 @@
-
 import logging
 import re
+
 
 class MetricsMixin:
     """
@@ -53,4 +53,3 @@ class MetricsMixin:
             _telemetry[key] = val
 
         return _logs, _telemetry
-

--- a/mozalert/metrics/queue.py
+++ b/mozalert/metrics/queue.py
@@ -1,4 +1,3 @@
-
 import logging
 import queue
 from types import SimpleNamespace
@@ -6,6 +5,7 @@ from mozalert.metrics.config import MetricsConfig
 from collections import namedtuple
 
 QueueItem = namedtuple("QueueItem", ["key", "name", "namespace", "labels", "value"])
+
 
 class MetricsQueue:
     def __init__(self):
@@ -67,4 +67,3 @@ class MetricsQueue:
     @q.setter
     def q(self, q):
         self._q = q
-

--- a/mozalert/metrics/thread.py
+++ b/mozalert/metrics/thread.py
@@ -8,20 +8,19 @@ from prometheus_client import CollectorRegistry, Gauge, push_to_gateway, Counter
 
 from mozalert.metrics.config import MetricsConfig
 
-SupportedMetricTypes = [ "Counter", "Gauge" ]
+SupportedMetricTypes = ["Counter", "Gauge"]
+
 
 class MetricsThread(threading.Thread):
     def __init__(self, q, shutdown=lambda: False, prometheus_gateway=None):
         super().__init__()
         # metrics_queue object
-        self.q = q 
+        self.q = q
         self.prometheus_gateway = prometheus_gateway
         self.shutdown = shutdown
 
         if not self.prometheus_gateway:
             self.prometheus_gateway = os.environ.get("PROMETHEUS_GATEWAY", None)
-
-        self.setName("metrics-thread")
 
     def terminate(self):
         return self.join()
@@ -68,7 +67,9 @@ class MetricsThread(threading.Thread):
                 if self.prometheus_gateway:
                     logging.debug("pushing metric to prometheus")
                     push_to_gateway(
-                        self.prometheus_gateway, job="mozalert.metrics", registry=registry
+                        self.prometheus_gateway,
+                        job="mozalert.metrics",
+                        registry=registry,
                     )
             except Exception as e:
                 logging.info(e)

--- a/mozalert/validate.py
+++ b/mozalert/validate.py
@@ -17,6 +17,7 @@ class Validator:
     instead of running mozalert, check to be sure mozalert
     is currently running and installed correctly.
     """
+
     def __init__(self, domain, version, plural):
         self.domain = domain
         self.version = version
@@ -38,8 +39,10 @@ class Validator:
             return False
         return True
 
+
 def main():
     return Validator(*sys.argv[1:]).run()
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/tests/events.py
+++ b/tests/events.py
@@ -35,7 +35,7 @@ re_add_event = {
         },
         "spec": {
             "check_cm": "check-test-login-cm",
-            "check_interval": "1m",
+            "check_interval": "10m",
             "escalations": [{"args": {"email": "afrank@mozilla.com"}, "type": "email"}],
             "image": "afrank/mozlenium",
             "max_attempts": 25,

--- a/tests/unit/test_escalations.py
+++ b/tests/unit/test_escalations.py
@@ -2,15 +2,16 @@ import unittest
 import unittest.mock as mock
 import os
 
-from mozalert import event
+from mozalert.events import event
 
 from tests import events
+
 
 class TestEscalations(unittest.TestCase):
     def test_escalation_parser(self):
         event_blob = events.add_event
         event_blob["object"]["spec"]["escalations"] = []
-        esc = { "type": "email", "args": { "email": "afrank@mozilla.com" } }
+        esc = {"type": "email", "args": {"email": "afrank@mozilla.com"}}
 
         event_blob["object"]["spec"]["escalations"] += [esc]
 
@@ -22,7 +23,7 @@ class TestEscalations(unittest.TestCase):
 
         os.environ[test_key] = test_email
 
-        env_esc = { "type": "email", "env_args": { "email": test_key } }
+        env_esc = {"type": "email", "env_args": {"email": test_key}}
 
         event_blob["object"]["spec"]["escalations"] += [env_esc]
 
@@ -32,6 +33,6 @@ class TestEscalations(unittest.TestCase):
 
         assert len(evt.config.escalations) == 2, "Wrong number of escalations!"
 
-        assert evt.config.escalations[1]["args"]["email"] == test_email, "env_args were not parsed correctly!"
-
-        
+        assert (
+            evt.config.escalations[1]["args"]["email"] == test_email
+        ), "env_args were not parsed correctly!"


### PR DESCRIPTION
The goal of this PR was to clarify the purpose of the controller; historically it has served multiple purposes but with these changes the controller now starts and maintains various threads, and all the work of receiving events and correlating that to checks is done by worker threads which the controller manages. 

This doesn't change the functionality a great deal, but does allow us to add better thread management to the controller, so now it actively checks if all its threads are working and restarts them if not.  It should also speed things up, since the work of 1 thread is now done by 3. This covers https://jira.mozilla.com/browse/SE-1202

Tl;dr:
* Reorganizing code in checks/ and events/
* Move k8s event handling out of the controller to its own thread, the event-handler
* Move check thread management out of the controller to its own thread, the check-handler
* Black formatting

Testing:
* Unit tests have been updated and run
* tested in afrank-dev with limited check load
* tested in mozilla-it-service-engineering under full check load with metrics enabled.

@bowlofstew a review please