### PR TITLE
better handling of CRD parameters (domain, version, plural)

### DIFF
--- a/mozalert/checks/check.py
+++ b/mozalert/checks/check.py
@@ -171,10 +171,10 @@ class Check(base.BaseCheck, metrics.mixin.MetricsMixin):
 
         try:
             res = self.kube.CustomObjectsApi.patch_namespaced_custom_object_status(
-                "crd.k8s.afrank.local",
-                "v1",
+                self.kube.domain,
+                self.kube.version,
                 self.config.namespace,
-                "checks",
+                self.kube.plural,
                 self.config.name,
                 body=self.status.crd_status,
             )

--- a/mozalert/checks/monitor.py
+++ b/mozalert/checks/monitor.py
@@ -11,9 +11,6 @@ class CheckMonitor(threading.Thread):
     def __init__(self, **kwargs):
         super().__init__()
         self.kube = kwargs.get("kube")
-        self.domain = kwargs.get("domain")
-        self.version = kwargs.get("version")
-        self.plural = kwargs.get("plural")
 
         self.interval = kwargs.get("interval", 60)
 
@@ -67,7 +64,7 @@ class CheckMonitor(threading.Thread):
         checks = {}
         try:
             check_list = self.kube.CustomObjectsApi.list_cluster_custom_object(
-                self.domain, self.version, self.plural, watch=False
+                self.kube.domain, self.kube.version, self.kube.plural, watch=False
             )
         except Exception as e:
             logging.error(e)

--- a/mozalert/controller.py
+++ b/mozalert/controller.py
@@ -17,9 +17,9 @@ class Controller(threading.Thread):
     def __init__(self, **kwargs):
         super().__init__()
 
-        self.domain = kwargs.get("domain", "crd.k8s.afrank.local")
-        self.version = kwargs.get("version", "v1")
-        self.plural = kwargs.get("plural", "checks")
+        domain = kwargs.get("domain")
+        version = kwargs.get("version")
+        plural = kwargs.get("plural")
 
         self.shutdown = kwargs.get("shutdown", lambda: False)
 
@@ -28,7 +28,7 @@ class Controller(threading.Thread):
         self.metrics_queue = metrics.queue.MetricsQueue()
         self.event_queue = events.queue.EventQueue()
 
-        self.kube = kubeclient.KubeClient()
+        self.kube = kubeclient.KubeClient(domain, version, plural)
 
         self.threads = {}
 
@@ -109,9 +109,6 @@ class Controller(threading.Thread):
             "healthcheck-thread",
             checks.monitor.CheckMonitor,
             kube=self.kube,
-            domain=self.domain,
-            version=self.version,
-            plural=self.plural,
             interval=self._check_monitor_interval,
         )
 
@@ -126,9 +123,6 @@ class Controller(threading.Thread):
             events.handler.EventHandler,
             q=self.event_queue,
             kube=self.kube,
-            domain=self.domain,
-            version=self.version,
-            plural=self.plural,
         )
 
         # start the check handler

--- a/mozalert/kubeclient.py
+++ b/mozalert/kubeclient.py
@@ -11,7 +11,7 @@ class KubeClient:
     for talking to kubernetes
     """
 
-    def __init__(self):
+    def __init__(self, domain="", version="", plural=""):
         if "KUBERNETES_PORT" in os.environ:
             config.load_incluster_config()
         else:
@@ -28,6 +28,10 @@ class KubeClient:
         self._CoreV1Api = client.CoreV1Api()
         self._CustomObjectsApi = client.CustomObjectsApi(self._api_client)
 
+        self._domain = domain
+        self._version = version
+        self._plural = plural
+
     @property
     def BatchV1Api(self):
         return self._BatchV1Api
@@ -39,6 +43,18 @@ class KubeClient:
     @property
     def CustomObjectsApi(self):
         return self._CustomObjectsApi
+
+    @property
+    def domain(self):
+        return self._domain
+
+    @property
+    def version(self):
+        return self._version
+
+    @property
+    def plural(self):
+        return self._plural
 
     @staticmethod
     def make_job(name, **kwargs):

--- a/mozalert/main.py
+++ b/mozalert/main.py
@@ -3,12 +3,17 @@
 import sys
 import logging
 import signal
+import os
 
 from mozalert.controller import Controller
 
 logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(threadName)s: %(message)s", level=logging.INFO
 )
+
+domain = os.environ.get("DOMAIN", "crd.k8s.afrank.local")
+version = os.environ.get("VERSION", "v1")
+plural = os.environ.get("PLURAL", "checks")
 
 
 class MainThread:
@@ -18,7 +23,12 @@ class MainThread:
 
         self.shutdown = False
 
-        self.controller = Controller(shutdown=lambda: self.shutdown)
+        self.controller = Controller(
+            domain=domain,
+            version=version,
+            plural=plural,
+            shutdown=lambda: self.shutdown,
+        )
         self.controller.start()
 
     def terminate(self, signum=-1, frame=None):

--- a/mozalert/validate.py
+++ b/mozalert/validate.py
@@ -19,10 +19,7 @@ class Validator:
     """
 
     def __init__(self, domain, version, plural):
-        self.domain = domain
-        self.version = version
-        self.plural = plural
-        self.kube = kubeclient.KubeClient()
+        self.kube = kubeclient.KubeClient(domain, version, plural)
 
     def run(self):
         if not self.validate_crd():
@@ -31,7 +28,7 @@ class Validator:
     def validate_crd(self):
         try:
             check_list = self.kube.CustomObjectsApi.list_cluster_custom_object(
-                self.domain, self.version, self.plural, watch=False
+                self.kube.domain, self.kube.version, self.kube.plural, watch=False
             )
         except Exception as e:
             logging.error(e)

--- a/tests/fake.py
+++ b/tests/fake.py
@@ -39,3 +39,15 @@ class FakeClient:
 
     def make_job(*args, **kwargs):
         return None
+
+    @property
+    def domain(self):
+        return "crd.k8s.afrank.local"
+
+    @property
+    def version(self):
+        return "v1"
+
+    @property
+    def plural(self):
+        return "checks"


### PR DESCRIPTION
This PR takes the name parameters of the CRD: domain, version and plural, and moves them to main.py,  overridable by environment variables, and adds them to the kube client object. This change has no functional impact on the running software, but is good housekeeping.

https://jira.mozilla.com/browse/SE-1203
As noted in the story this relates to a comment from a previous PR:  https://github.com/mozilla-it/mozalert/pull/11#discussion_r462372465

This has gone through what has become my typical battery of tests:
- unit tests updated, cover these changes, and have been run successfully
- Run locally (via pip) and in afrank-dev with a set of test checks
- Burned in on mozilla-it-service-engineering with prod check load and metrics+alerting enabled. 