### PR TITLE
Adding check source as a config item to be passed through

### DIFF
--- a/charts/mozalert-controller/Chart.yaml
+++ b/charts/mozalert-controller/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.16.0
+appVersion: 1.17.0

--- a/charts/mozalert-controller/crds/crd.yaml
+++ b/charts/mozalert-controller/crds/crd.yaml
@@ -51,6 +51,9 @@ spec:
                 type: string
               check_url:
                 type: string
+              references:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               args:
                 type: array
                 items:

--- a/mozalert/checks/base.py
+++ b/mozalert/checks/base.py
@@ -187,7 +187,10 @@ class BaseCheck:
                 )
                 Escalation = getattr(module, "Escalation")
                 e = Escalation(
-                    f"{self}", args=args, config=self.config, status=self.status,
+                    f"{self}",
+                    args=args,
+                    config=self.config,
+                    status=self.status,
                 )
                 e.run()
             except Exception as e:

--- a/mozalert/checks/check.py
+++ b/mozalert/checks/check.py
@@ -33,15 +33,13 @@ class Check(base.BaseCheck, metrics.mixin.MetricsMixin):
         """
         Build the k8s resources, apply them, then poll for completion, and
         report status back to the thread.
-        
+
         The k8s resources take the form:
             pod spec -> pod template -> job spec -> job
 
         """
         logging.debug(f"Running job")
-
         job = self.kube.make_job(self.config.name, **self.config.pod_spec)
-
         try:
             res = self.kube.BatchV1Api.create_namespaced_job(
                 body=job, namespace=self.config.namespace

--- a/mozalert/checks/config.py
+++ b/mozalert/checks/config.py
@@ -1,4 +1,5 @@
 import os
+from collections import namedtuple
 
 
 class CheckConfig:
@@ -21,6 +22,7 @@ class CheckConfig:
         self._escalations = self.parse_escalations(kwargs.get("escalations", []))
         self._max_attempts = int(kwargs.get("max_attempts", "3"))
         self._check_url = kwargs.get("check_url", None)
+        self.references = self.parse_to_object(kwargs.get("references", {}))
         self._timeout = float(kwargs.get("timeout", 0))
 
         self.labels = kwargs.get("labels", {})
@@ -56,6 +58,14 @@ class CheckConfig:
     @check_url.setter
     def check_url(self, check_url):
         self._check_url = check_url
+
+    @property
+    def references(self):
+        return self._references
+
+    @references.setter
+    def references(self, references):
+        self._references = references
 
     @property
     def notification_interval(self):
@@ -122,6 +132,16 @@ class CheckConfig:
                 del e["env_args"]
             _escalations += [e]
         return _escalations
+
+    @staticmethod
+    def parse_to_object(tmp_dict):
+        """
+        Tested with a single depth dict, converts a dict to an object.
+        Given a = {'test': 'testval'}, a.test == 'testval' after being passed to this function.
+        """
+        tmp_dict = tmp_dict or {}
+        objNamedTuple = namedtuple("objNamedTuple", sorted(tmp_dict))
+        return objNamedTuple(**tmp_dict)
 
     def build_pod_spec(self, **kwargs):
         """

--- a/mozalert/checks/handler.py
+++ b/mozalert/checks/handler.py
@@ -7,10 +7,10 @@ class CheckHandler(threading.Thread):
     """
     the CheckHandler thread takes check events from the controller and process them as
     they come in. Each event has an associated operation:
-        
+
     ADDED: a new check has been created. the main thread creates a new check object which
            creates a threading.Timer set to the check_interval.
-        
+
     DELETED: a check has been removed. Cancel/resolve any running threads and delete the
              check object.
 

--- a/mozalert/controller.py
+++ b/mozalert/controller.py
@@ -84,7 +84,9 @@ class Controller(threading.Thread):
             self.threads[name].thread.join()
 
         self.new_thread(
-            name, self.threads[name].obj, **self.threads[name].kwargs,
+            name,
+            self.threads[name].obj,
+            **self.threads[name].kwargs,
         )
 
     def run(self):

--- a/mozalert/escalations/email.py
+++ b/mozalert/escalations/email.py
@@ -28,6 +28,16 @@ class Escalation(BaseEscalation):
             self.message += (
                 "\n" + f"<b>More Details:</b><br> <pre>{self.status.logs}</pre><br>"
             )
+
+        # When we find another thing to reference, we should generalize this line.  As is we are only
+        # going to pass the source code reference to email.
+        if self.config.references:
+            if self.config.references.source_code:
+                self.message += (
+                    "\n"
+                    + f"<b>Source Code for Check:</b><br> <pre>{self.config.references.source_code}</pre><br>"
+                )
+
         self.message += "\n" + "</p>"
         self.subject = f"Mozalert {self.status.status.name}: {self.name}"
 

--- a/mozalert/escalations/slack.py
+++ b/mozalert/escalations/slack.py
@@ -54,6 +54,12 @@ class Escalation(BaseEscalation):
         if self.config.check_url:
             more_details += [f"<{self.config.check_url}|view failed url>"]
 
+        # we're hard coding just one type of reference
+        # once we have an example of another reference type, it'd probably be good to generalize
+        if self.config.references:
+            if self.config.references.source_code:
+                more_details += [f"<{self.config.references.source_code}|view source>"]
+
         color = "#ff0000"  # red
         if self.status.status.name == "OK":
             color = "#36a64f"  # green

--- a/mozalert/events/event.py
+++ b/mozalert/events/event.py
@@ -57,6 +57,7 @@ class Event:
             timeout=self.parse_time(self._check_spec.get("timeout", "5m")).seconds,
             pod_spec=self._check_spec.get("template", {}).get("spec", {}),
             check_url=self._check_spec.get("check_url", None),
+            references=self._check_spec.get("references", {}),
             labels=self._metadata.get("labels", {}),
         )
 

--- a/mozalert/kubeclient.py
+++ b/mozalert/kubeclient.py
@@ -65,7 +65,8 @@ class KubeClient:
         """
         pod_spec = client.V1PodSpec(**kwargs)
         template = client.V1PodTemplateSpec(
-            metadata=client.V1ObjectMeta(labels={"app": name}), spec=pod_spec,
+            metadata=client.V1ObjectMeta(labels={"app": name}),
+            spec=pod_spec,
         )
         job_spec = client.V1JobSpec(template=template, backoff_limit=0)
         job = client.V1Job(

--- a/mozalert/metrics/config.py
+++ b/mozalert/metrics/config.py
@@ -1,9 +1,30 @@
 MetricsConfig = {
-    "mozalert_check_get_time": {"type": "Gauge", "labels": ["status", "escalated"],},
-    "mozalert_check_node_time": {"type": "Gauge", "labels": ["status", "escalated"],},
-    "mozalert_check_runtime": {"type": "Gauge", "labels": ["status", "escalated"],},
-    "mozalert_check_total_time": {"type": "Gauge", "labels": ["status", "escalated"],},
-    "mozalert_check_latency": {"type": "Gauge", "labels": ["status", "escalated"],},
-    "mozalert_check_escalations": {"type": "Gauge", "labels": [],},
-    "mozalert_check_failures": {"type": "Gauge", "labels": [],},
+    "mozalert_check_get_time": {
+        "type": "Gauge",
+        "labels": ["status", "escalated"],
+    },
+    "mozalert_check_node_time": {
+        "type": "Gauge",
+        "labels": ["status", "escalated"],
+    },
+    "mozalert_check_runtime": {
+        "type": "Gauge",
+        "labels": ["status", "escalated"],
+    },
+    "mozalert_check_total_time": {
+        "type": "Gauge",
+        "labels": ["status", "escalated"],
+    },
+    "mozalert_check_latency": {
+        "type": "Gauge",
+        "labels": ["status", "escalated"],
+    },
+    "mozalert_check_escalations": {
+        "type": "Gauge",
+        "labels": [],
+    },
+    "mozalert_check_failures": {
+        "type": "Gauge",
+        "labels": [],
+    },
 }

--- a/mozalert/metrics/mixin.py
+++ b/mozalert/metrics/mixin.py
@@ -35,7 +35,7 @@ class MetricsMixin:
     @staticmethod
     def extract_telemetry_from_logs(logs):
         """
-        we support some basic telemetry in log responses from checks. 
+        we support some basic telemetry in log responses from checks.
         this allows one to pass telemetry back to the controller
         without needing to implement additional clients.
         """

--- a/mozalert/status.py
+++ b/mozalert/status.py
@@ -30,8 +30,8 @@ class EnumState(Enum):
 
 class Status:
     """
-    the status object is our python representation of the 
-    status subresource in our check crd object. 
+    the status object is our python representation of the
+    status subresource in our check crd object.
     """
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
Check Source is intended to be a url to say a github repo to find a check.
Since we're sometimes doing fairly complex things (like grabbing a particular div)
getting quickly to the actual source seems helpful.
Also ran black on the repo.